### PR TITLE
#23   [terraform] NATゲートウェイを削除する-1 

### DIFF
--- a/terraform/ecr/ecr.tf
+++ b/terraform/ecr/ecr.tf
@@ -1,5 +1,3 @@
-variable "ecr-name" {}
-
 resource "aws_ecr_repository" "main" {
   name                 = var.ecr-name
   image_tag_mutability = "MUTABLE"

--- a/terraform/ecr/variables.tf
+++ b/terraform/ecr/variables.tf
@@ -4,7 +4,7 @@ variable "ecr-name" {
 variable vpc-id {
     type = string
 }
-variable aws_subnet_private_ids {
+variable aws_subnet_private_ips {
     type = list(string)
 }
 variable vpc_cidr {

--- a/terraform/ecr/variables.tf
+++ b/terraform/ecr/variables.tf
@@ -1,3 +1,12 @@
 variable "ecr-name" {
     type = string
 }
+variable vpc-id {
+    type = string
+}
+variable aws_subnet_private_ids {
+    type = list(string)
+}
+variable vpc_cidr {
+    type = string
+}

--- a/terraform/ecr/variables.tf
+++ b/terraform/ecr/variables.tf
@@ -1,0 +1,3 @@
+variable "ecr-name" {
+    type = string
+}

--- a/terraform/ecr/vpc_endpoint.tf
+++ b/terraform/ecr/vpc_endpoint.tf
@@ -16,7 +16,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id              = var.vpc-id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = aws_subnet.app_private[*].id
+  subnet_ids          = var.aws_subnet_private_ips
   security_group_ids  = [aws_security_group.vpc_endpoint.id]
   private_dns_enabled = true
 }

--- a/terraform/ecr/vpc_endpoint.tf
+++ b/terraform/ecr/vpc_endpoint.tf
@@ -1,0 +1,22 @@
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = var.vpc-id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  #The ID of one or more subnets in which to create a network interface for the endpoint.
+  # その中にネットワークインターフェース(VPCエンドポイント)を作るためのサブネットのID
+  # プライベートサブネットに外部ヘ行く道がなくて困っているので、VPCエンドポイントを作成する？
+  #Applicable for endpoints of type GatewayLoadBalancer and Interface.
+
+  subnet_ids = var.aws_subnet_private_ips
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = var.vpc-id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.app_private[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}

--- a/terraform/ecr/vpc_endpoint_security.tf
+++ b/terraform/ecr/vpc_endpoint_security.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "vpc_endpoint" {
+  name   = "vpc_endpoint_sg"
+  vpc_id = var.vpc-id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr] # 本当は 0.0.0.0 で設定してみてもいいけど
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+}

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -19,8 +19,11 @@ provider "aws" {
 module "ecr-app" {
   source   = "../../ecr"
   ecr-name = "${var.ecr-name2}-${var.project-name-app}"
-
+  vpc-id = module.vpc.vpc-id
+  aws_subnet_private_ips = module.vpc.aws_subnet_private_ips
+  vpc_cidr = module.vpc.vpc_cidr
 }
+
 # module "ecr-bot-server" {
 #   source   = "../../ecr"
 #   ecr-name = "${var.ecr-name2}-${var.project-name-bot-server}"

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -19,11 +19,12 @@ provider "aws" {
 module "ecr-app" {
   source   = "../../ecr"
   ecr-name = "${var.ecr-name2}-${var.project-name-app}"
+
 }
-module "ecr-bot-server" {
-  source   = "../../ecr"
-  ecr-name = "${var.ecr-name2}-${var.project-name-bot-server}"
-}
+# module "ecr-bot-server" {
+#   source   = "../../ecr"
+#   ecr-name = "${var.ecr-name2}-${var.project-name-bot-server}"
+# }
 
 module "route53" {
   source      = "../../route53"

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -17,11 +17,11 @@ provider "aws" {
 }
 
 module "ecr-app" {
-  source   = "../../ecr"
-  ecr-name = "${var.ecr-name2}-${var.project-name-app}"
-  vpc-id = module.vpc.vpc-id
+  source                 = "../../ecr"
+  ecr-name               = "${var.ecr-name2}-${var.project-name-app}"
+  vpc-id                 = module.vpc.vpc-id
   aws_subnet_private_ips = module.vpc.aws_subnet_private_ips
-  vpc_cidr = module.vpc.vpc_cidr
+  vpc_cidr               = module.vpc.vpc_cidr
 }
 
 # module "ecr-bot-server" {

--- a/terraform/vpc/output.tf
+++ b/terraform/vpc/output.tf
@@ -7,3 +7,7 @@ output "aws_subnet_public_ips" {
 output "aws_subnet_private_ips" {
     value = aws_subnet.privates.*.id
 }
+
+output "vpc_cidr" {
+    value = var.vpc_cidr
+}

--- a/terraform/vpc/vpc.tf
+++ b/terraform/vpc/vpc.tf
@@ -135,14 +135,15 @@ resource "aws_route_table" "privates" {
   }
 }
 
-resource "aws_route" "privates" {
-  count = length(var.private_subnet_cidrs)
+# NATをオフにする
+# resource "aws_route" "privates" {
+#   count = length(var.private_subnet_cidrs)
 
-  destination_cidr_block = "0.0.0.0/0"
+#   destination_cidr_block = "0.0.0.0/0"
 
-  route_table_id = element(aws_route_table.privates.*.id, count.index)
-  nat_gateway_id = element(aws_nat_gateway.this.*.id, count.index)
-}
+#   route_table_id = element(aws_route_table.privates.*.id, count.index)
+#   nat_gateway_id = element(aws_nat_gateway.this.*.id, count.index)
+# }
 
 resource "aws_route_table_association" "privates" {
   count = length(var.private_subnet_cidrs)

--- a/terraform/vpc/vpc.tf
+++ b/terraform/vpc/vpc.tf
@@ -54,27 +54,27 @@ resource "aws_internet_gateway" "main" {
 }
 
 # NAT ゲートウェイ 用 Elastic IP付与 (public に NAT ゲートウェイを接続)
-resource "aws_eip" "nat" {
-  count = length(var.public_subnet_cidrs)
+# resource "aws_eip" "nat" {
+#   count = length(var.public_subnet_cidrs)
 
-  vpc = true
+#   vpc = true
 
-  tags = {
-    Name = "${var.app-name}-natgw-${count.index}"
-  }
-}
+#   tags = {
+#     Name = "${var.app-name}-natgw-${count.index}"
+#   }
+# }
 
-# NAT ゲートウェイ
-resource "aws_nat_gateway" "this" {
-  count = length(var.public_subnet_cidrs)
+# # NAT ゲートウェイ
+# resource "aws_nat_gateway" "this" {
+#   count = length(var.public_subnet_cidrs)
 
-  subnet_id     = element(aws_subnet.publics.*.id, count.index)
-  allocation_id = element(aws_eip.nat.*.id, count.index) # ここで eip をつないでいる
+#   subnet_id     = element(aws_subnet.publics.*.id, count.index)
+#   allocation_id = element(aws_eip.nat.*.id, count.index) # ここで eip をつないでいる
 
-  tags = {
-    Name = "${var.app-name}-${count.index}"
-  }
-}
+#   tags = {
+#     Name = "${var.app-name}-${count.index}"
+#   }
+# }
 
 # ルートテーブル
 # Route Table


### PR DESCRIPTION
#23
- [terraform] NAT ゲートウェイをコメントアウト
- [terraform] [ECR] variables の分割
- [terraform] var vpc のvpc_cidr とか ips を利用するためにいろいろ変数の出し入れした
- [terraform] ECR のところに、VPC endpoint を作成してみた。
- [terraform] main.tf OFF ecr-bot-server これ今使ってないので
- [terraform] main.tf とかvariables の変数名修正を validate にしたがう
- [terraform] vpc.tf NATをオフにするために、resource aws_route privates をオフにした。(nat gateway_id が存在するため)
- [terraform] FMT
