### PR TITLE
#23 [terraform] ECRからNATゲートウェイなしでもデータ取得できるか確認-2 s3 vpc_endpoint 

### DIFF
--- a/terraform/ecr/variables.tf
+++ b/terraform/ecr/variables.tf
@@ -10,3 +10,7 @@ variable "aws_subnet_private_ips" {
 variable "vpc_cidr" {
   type = string
 }
+
+variable "route_table_ids_for_private" {
+  type = list(string)
+}

--- a/terraform/ecr/vpc_endpoint.tf
+++ b/terraform/ecr/vpc_endpoint.tf
@@ -30,7 +30,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint_route_table_association" "private_s3" {
-  count           = length(aws_subnet.app_private)
+  count           = length(var.route_table_ids_for_private)
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
-  route_table_id  = var.route_table_ids_for_private[count.index].id
+  route_table_id  = var.route_table_ids_for_private[count.index]
 }

--- a/terraform/ecr/vpc_endpoint.tf
+++ b/terraform/ecr/vpc_endpoint.tf
@@ -20,3 +20,17 @@ resource "aws_vpc_endpoint" "ecr_api" {
   security_group_ids  = [aws_security_group.vpc_endpoint.id]
   private_dns_enabled = true
 }
+
+
+# s3 の vpc endpoint 作成
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.vpc-id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = "Gateway"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+  count           = length(aws_subnet.app_private)
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  route_table_id  = var.route_table_ids_for_private[count.index].id
+}

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -63,5 +63,5 @@ module "ecs" {
   container_name               = var.container_name
   container_port               = var.container_port
   aws_ecr_repository_name      = module.ecr-app.aws_ecr_repository_name
-  route_table_ids_for_private = module.vpc.route_table_ids_for_private
+  route_table_ids_for_private  = module.vpc.route_table_ids_for_private
 }

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -17,11 +17,12 @@ provider "aws" {
 }
 
 module "ecr-app" {
-  source                 = "../../ecr"
-  ecr-name               = "${var.ecr-name2}-${var.project-name-app}"
-  vpc-id                 = module.vpc.vpc-id
-  aws_subnet_private_ips = module.vpc.aws_subnet_private_ips
-  vpc_cidr               = module.vpc.vpc_cidr
+  source                      = "../../ecr"
+  ecr-name                    = "${var.ecr-name2}-${var.project-name-app}"
+  vpc-id                      = module.vpc.vpc-id
+  aws_subnet_private_ips      = module.vpc.aws_subnet_private_ips
+  vpc_cidr                    = module.vpc.vpc_cidr
+  route_table_ids_for_private = module.vpc.route_table_ids_for_private
 }
 
 # module "ecr-bot-server" {
@@ -63,5 +64,4 @@ module "ecs" {
   container_name               = var.container_name
   container_port               = var.container_port
   aws_ecr_repository_name      = module.ecr-app.aws_ecr_repository_name
-  route_table_ids_for_private  = module.vpc.route_table_ids_for_private
 }

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -63,4 +63,5 @@ module "ecs" {
   container_name               = var.container_name
   container_port               = var.container_port
   aws_ecr_repository_name      = module.ecr-app.aws_ecr_repository_name
+  route_table_ids_for_private = module.vpc.route_table_ids_for_private
 }

--- a/terraform/vpc/output.tf
+++ b/terraform/vpc/output.tf
@@ -11,3 +11,6 @@ output "aws_subnet_private_ips" {
 output "vpc_cidr" {
   value = var.vpc_cidr
 }
+output "route_table_ids_for_private" {
+  value = aws_route_table.privates.*.id
+}


### PR DESCRIPTION
#23

## これまで
- [terraform] コンテナタグを直近の 0.0.1-5191cf8 に修正. ECRから NATゲートウェイなしでデータを取得できるか
s3 の失敗か何かでコンテナ作成できず

## これから

- [terraform] ADD new variable route_table_ids_for_private for ecr/vpc_endpoint ここに s3 への VPC エンドポイントも作成する
- [terraform] FMT
